### PR TITLE
Iterator pattern for LightHTML traversal

### DIFF
--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Iterator/BreadthFirstIterator.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Iterator/BreadthFirstIterator.cs
@@ -1,0 +1,27 @@
+﻿using StructuralPatterns.Composite;
+
+namespace StructuralPatterns.BehavioralPatterns.Iterator
+{
+    public class BreadthFirstIterator : ILightNodeIterator
+    {
+        private readonly Queue<LightNode> _queue = new Queue<LightNode>();
+
+        public BreadthFirstIterator(LightNode root)
+        {
+            _queue.Enqueue(root);
+        }
+
+        public bool HasNext() => _queue.Count > 0;
+
+        public LightNode Next()
+        {
+            var node = _queue.Dequeue();
+            if (node is LightElementNode elem)
+            {
+                foreach (var child in elem.Children)
+                    _queue.Enqueue(child);
+            }
+            return node;
+        }
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Iterator/DepthFirstIterator.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Iterator/DepthFirstIterator.cs
@@ -1,0 +1,27 @@
+﻿using StructuralPatterns.Composite;
+
+namespace StructuralPatterns.BehavioralPatterns.Iterator
+{
+    public class DepthFirstIterator : ILightNodeIterator
+    {
+        private readonly Stack<LightNode> _stack = new Stack<LightNode>();
+
+        public DepthFirstIterator(LightNode root)
+        {
+            _stack.Push(root);
+        }
+
+        public bool HasNext() => _stack.Count > 0;
+
+        public LightNode Next()
+        {
+            var node = _stack.Pop();
+            if (node is LightElementNode elem)
+            {
+                for (int i = elem.Children.Count - 1; i >= 0; i--)
+                    _stack.Push(elem.Children[i]);
+            }
+            return node;
+        }
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Iterator/ILightNodeIterator.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Iterator/ILightNodeIterator.cs
@@ -1,0 +1,10 @@
+﻿using StructuralPatterns.Composite;
+
+namespace StructuralPatterns.BehavioralPatterns.Iterator
+{
+    public interface ILightNodeIterator
+    {
+        bool HasNext();
+        LightNode Next();
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightElementNode.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightElementNode.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 
 namespace StructuralPatterns.Composite
 {

--- a/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightNode.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightNode.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace StructuralPatterns.Composite
+﻿namespace StructuralPatterns.Composite
 {
     public abstract class LightNode
     {

--- a/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightTextNode.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightTextNode.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace StructuralPatterns.Composite
+﻿namespace StructuralPatterns.Composite
 {
     public class LightTextNode : LightNode
     {

--- a/lab-3/StructuralPatterns/StructuralPatterns/Program.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/Program.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Net.Http;
 using System.Collections.Generic;
+using StructuralPatterns.BehavioralPatterns.Iterator;
 
 namespace StructuralPatterns
 {
@@ -181,15 +182,34 @@ namespace StructuralPatterns
         static void Task5()
         {
             // Завдання 5: Компонувальник
-            Console.WriteLine(">> Composite Demo:\n");
-            // Створення простого HTML елементу: <div> з внутрішніми елементами
+            Console.WriteLine("\n>> Composite Demo:\n");
+
             LightElementNode div = new LightElementNode("div");
             div.CssClasses.Add("container");
+
             LightElementNode p = new LightElementNode("p");
             p.Children.Add(new LightTextNode("This is a paragraph."));
             div.Children.Add(p);
+
+            LightElementNode span = new LightElementNode("span");
+            span.Children.Add(new LightTextNode("And this is a span."));
+            div.Children.Add(span);
+
             Console.WriteLine("OuterHTML: " + div.OuterHTML());
             Console.WriteLine("InnerHTML: " + div.InnerHTML());
+            Console.WriteLine();
+
+            // --- 1) Iterator Demo ---
+            Console.WriteLine(">> Iterator Demo:\n");
+            var root = div; // використовуємо вже створений div-приклад
+            Console.WriteLine("Depth-First Traversal:");
+            var dfs = new DepthFirstIterator(root);
+            while (dfs.HasNext())
+                Console.WriteLine("  " + dfs.Next().OuterHTML());
+            Console.WriteLine("Breadth-First Traversal:");
+            var bfs = new BreadthFirstIterator(root);
+            while (bfs.HasNext())
+                Console.WriteLine("  " + bfs.Next().OuterHTML());
             Console.WriteLine();
         }
     }


### PR DESCRIPTION
## Що зроблено
Додано підтримку двох ітераторів для обходу дерева LightHTML:
- **DepthFirstIterator** — обхід в глибину.
- **BreadthFirstIterator** — обхід в ширину.

## Зміни
- Інтерфейс `ILightNodeIterator` (HasNext(), Next()).
- Реалізації `DepthFirstIterator` і `BreadthFirstIterator` в просторі імен `BehavioralPatterns.Iterator`.

## Як тестувати
1. Створити простий `LightElementNode` з дітьми.
2. Викликати `new DepthFirstIterator(root)` та/або `new BreadthFirstIterator(root)`.
3. Виконувати цикл `while (iterator.HasNext()) Console.WriteLine(iterator.Next().OuterHTML());` — перевірити порядок обходу.

---
