### PR TITLE
Command pattern for LightHTML modifications

### DIFF
--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Command/AddChildCommand.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Command/AddChildCommand.cs
@@ -1,0 +1,26 @@
+﻿using StructuralPatterns.Composite;
+
+namespace StructuralPatterns.BehavioralPatterns.Command
+{
+    public class AddChildCommand : ICommand
+    {
+        private readonly LightElementNode _parent;
+        private readonly LightNode _child;
+
+        public AddChildCommand(LightElementNode parent, LightNode child)
+        {
+            _parent = parent;
+            _child = child;
+        }
+
+        public void Execute()
+        {
+            _parent.Children.Add(_child);
+        }
+
+        public void Undo()
+        {
+            _parent.Children.Remove(_child);
+        }
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Command/CommandInvoker.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Command/CommandInvoker.cs
@@ -1,0 +1,31 @@
+﻿namespace StructuralPatterns.BehavioralPatterns.Command
+{
+    public class CommandInvoker
+    {
+        private readonly Stack<ICommand> _history = new Stack<ICommand>();
+        private readonly Stack<ICommand> _redoStack = new Stack<ICommand>();
+
+        public void ExecuteCommand(ICommand command)
+        {
+            command.Execute();
+            _history.Push(command);
+            _redoStack.Clear();
+        }
+
+        public void UndoLast()
+        {
+            if (_history.Count == 0) return;
+            var cmd = _history.Pop();
+            cmd.Undo();
+            _redoStack.Push(cmd);
+        }
+
+        public void RedoLast()
+        {
+            if (_redoStack.Count == 0) return;
+            var cmd = _redoStack.Pop();
+            cmd.Execute();
+            _history.Push(cmd);
+        }
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Command/ICommand.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Command/ICommand.cs
@@ -1,0 +1,8 @@
+﻿namespace StructuralPatterns.BehavioralPatterns.Command
+{
+    public interface ICommand
+    {
+        void Execute();
+        void Undo();
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Command/RemoveChildCommand.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Command/RemoveChildCommand.cs
@@ -1,0 +1,26 @@
+﻿using StructuralPatterns.Composite;
+
+namespace StructuralPatterns.BehavioralPatterns.Command
+{
+    public class RemoveChildCommand : ICommand
+    {
+        private readonly LightElementNode _parent;
+        private readonly LightNode _child;
+
+        public RemoveChildCommand(LightElementNode parent, LightNode child)
+        {
+            _parent = parent;
+            _child = child;
+        }
+
+        public void Execute()
+        {
+            _parent.Children.Remove(_child);
+        }
+
+        public void Undo()
+        {
+            _parent.Children.Add(_child);
+        }
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/Program.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/Program.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Net.Http;
 using System.Collections.Generic;
 using StructuralPatterns.BehavioralPatterns.Iterator;
+using StructuralPatterns.BehavioralPatterns.Command;
 
 namespace StructuralPatterns
 {
@@ -210,6 +211,27 @@ namespace StructuralPatterns
             var bfs = new BreadthFirstIterator(root);
             while (bfs.HasNext())
                 Console.WriteLine("  " + bfs.Next().OuterHTML());
+            Console.WriteLine();
+
+            // --- 2) Command Demo ---
+            Console.WriteLine(">> Command Demo:\n");
+            var invoker = new CommandInvoker();
+            var newP = new LightElementNode("p");
+            var text = new LightTextNode("Командний рядок додано!");
+            var addCmd = new AddChildCommand(div, newP);
+            var addTextCmd = new AddChildCommand(newP, text);
+            invoker.ExecuteCommand(addCmd);
+            invoker.ExecuteCommand(addTextCmd);
+            Console.WriteLine("After Execute:");
+            Console.WriteLine(div.OuterHTML());
+            invoker.UndoLast();  // прибираємо текст
+            invoker.UndoLast();  // прибираємо <p>
+            Console.WriteLine("After Undo:");
+            Console.WriteLine(div.OuterHTML());
+            invoker.RedoLast();  // повертаємо <p>
+            invoker.RedoLast();  // повертаємо текст
+            Console.WriteLine("After Redo:");
+            Console.WriteLine(div.OuterHTML());
             Console.WriteLine();
         }
     }


### PR DESCRIPTION
## Що зроблено
Реалізовано шаблон **Command** для додавання/видалення вузлів LightHTML з можливістю Undo/Redo:
- Інтерфейс `ICommand` (Execute, Undo).
- Команди `AddChildCommand`, `RemoveChildCommand`.
- Клас-інвокер `CommandInvoker` із стеком історії та підтримкою Redo.

## Зміни
- Простір імен `BehavioralPatterns.Command`.
- Додано методи Execute/Undo/Redo для управління змінами в `LightElementNode.Children`.

## Як тестувати
1. Створити `CommandInvoker invoker = new CommandInvoker();`
2. Скласти `AddChildCommand(div, newNode)` або `RemoveChildCommand(...)`.
3. Виконати `invoker.ExecuteCommand(cmd)` та перевірити `div.OuterHTML()`.
4. Викликати `invoker.UndoLast()` / `invoker.RedoLast()` для відкату та повторного застосування.

---