### PR TITLE
Visitor pattern for LightHTML tree processing

### DIFF
--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Visitor/IVisitor.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Visitor/IVisitor.cs
@@ -1,0 +1,10 @@
+﻿using StructuralPatterns.Composite;
+
+namespace StructuralPatterns.BehavioralPatterns.Visitor
+{
+    public interface IVisitor
+    {
+        void Visit(LightElementNode element);
+        void Visit(LightTextNode text);
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Visitor/StatsVisitor.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Visitor/StatsVisitor.cs
@@ -1,0 +1,35 @@
+﻿using StructuralPatterns.Composite;
+
+namespace StructuralPatterns.BehavioralPatterns.Visitor
+{
+    public class StatsVisitor : IVisitor
+    {
+        public int ElementCount { get; private set; } = 0;
+        public int TextCount { get; private set; } = 0;
+        public Dictionary<string, int> TagCounts { get; } = new Dictionary<string, int>();
+
+        public void Visit(LightElementNode element)
+        {
+            ElementCount++;
+
+            if (TagCounts.ContainsKey(element.TagName))
+                TagCounts[element.TagName]++;
+            else
+                TagCounts[element.TagName] = 1;
+        }
+
+        public void Visit(LightTextNode text)
+        {
+            TextCount++;
+        }
+
+        public void PrintStatistics()
+        {
+            Console.WriteLine($"Total elements: {ElementCount}");
+            Console.WriteLine($"Total text nodes: {TextCount}");
+            Console.WriteLine("Elements by tag:");
+            foreach (var kvp in TagCounts)
+                Console.WriteLine($"  <{kvp.Key}>: {kvp.Value}");
+        }
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Visitor/TextCountVisitor.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/BehavioralPatterns/Visitor/TextCountVisitor.cs
@@ -1,0 +1,14 @@
+﻿using StructuralPatterns.Composite;
+
+namespace StructuralPatterns.BehavioralPatterns.Visitor
+{
+    public class TextCountVisitor : IVisitor
+    {
+        public int Count { get; private set; }
+
+        public void Visit(LightElementNode element) { /* нічого */ }
+
+        public void Visit(LightTextNode text)
+            => Count++;
+    }
+}

--- a/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightElementNode.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightElementNode.cs
@@ -1,4 +1,5 @@
 ﻿using StructuralPatterns.BehavioralPatterns.State;
+using StructuralPatterns.BehavioralPatterns.Visitor;
 using System.Text;
 
 namespace StructuralPatterns.Composite
@@ -51,6 +52,13 @@ namespace StructuralPatterns.Composite
         {
             State = newState;
             State.Handle(this);
+        }
+
+        public override void Accept(IVisitor visitor)
+        {
+            visitor.Visit(this);
+            foreach (var c in Children)
+                c.Accept(visitor);
         }
     }
 }

--- a/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightNode.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightNode.cs
@@ -1,8 +1,11 @@
-﻿namespace StructuralPatterns.Composite
+﻿using StructuralPatterns.BehavioralPatterns.Visitor;
+
+namespace StructuralPatterns.Composite
 {
     public abstract class LightNode
     {
         public abstract string OuterHTML();
         public abstract string InnerHTML();
+        public abstract void Accept(IVisitor visitor);
     }
 }

--- a/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightTextNode.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/Composite/LightTextNode.cs
@@ -1,4 +1,6 @@
-﻿namespace StructuralPatterns.Composite
+﻿using StructuralPatterns.BehavioralPatterns.Visitor;
+
+namespace StructuralPatterns.Composite
 {
     public class LightTextNode : LightNode
     {
@@ -11,5 +13,6 @@
 
         public override string OuterHTML() => Text;
         public override string InnerHTML() => Text;
+        public override void Accept(IVisitor visitor) => visitor.Visit(this);
     }
 }

--- a/lab-3/StructuralPatterns/StructuralPatterns/Program.cs
+++ b/lab-3/StructuralPatterns/StructuralPatterns/Program.cs
@@ -12,6 +12,7 @@ using StructuralPatterns.BehavioralPatterns.Iterator;
 using StructuralPatterns.BehavioralPatterns.Command;
 using StructuralPatterns.BehavioralPatterns.State;
 using StructuralPatterns.BehavioralPatterns.TemplateMethod;
+using StructuralPatterns.BehavioralPatterns.Visitor;
 
 namespace StructuralPatterns
 {
@@ -255,6 +256,13 @@ namespace StructuralPatterns
 
             var renderedHtml = myDiv.Render();
             Console.WriteLine("Rendered HTML: " + renderedHtml);
+            Console.WriteLine();
+
+            // --- 5) Visitor Demo ---
+            Console.WriteLine(">> Visitor Demo:\n");
+            var statsVisitor = new StatsVisitor();
+            div.Accept(statsVisitor);
+            statsVisitor.PrintStatistics();
             Console.WriteLine();
         }
     }


### PR DESCRIPTION
## Що зроблено
Реалізовано шаблон **Visitor** для узгодженого обходу та обробки LightHTML-дерева:

- Додано інтерфейс `IVisitor` із методами:
  - `void Visit(LightElementNode element)`
  - `void Visit(LightTextNode text)`
- В `LightNode` (і його нащадках) реалізовано метод `Accept(IVisitor visitor)`, що:
  1. Викликає `visitor.Visit(this)` на поточному вузлі.
  2. Для `LightElementNode` рекурсивно передає `Accept` кожному дочірньому вузлу.
- Приклади візитерів:
  - **TextCountVisitor**: підрахунок усіх текстових вузлів.
  - **StatsVisitor**: збір статистики за кількістю елементів, текстових вузлів та частотою тегів.

## Зміни в коді
- Папка `BehavioralPatterns/Visitor` із файлами:
  - `IVisitor.cs`
  - `TextCountVisitor.cs`
  - `StatsVisitor.cs`
- Оновлення:
  - `LightNode`, `LightElementNode`, `LightTextNode`: додано метод `Accept`.

## Інструкція з тестування
1. Створіть дерево `LightElementNode` з вкладеними `LightTextNode`.
2. Запустіть:
   ```csharp
   var visitor = new TextCountVisitor();
   root.Accept(visitor);
   Console.WriteLine($"Text nodes: {visitor.Count}");

---
